### PR TITLE
Fix index error during registration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ build
 .classpath
 .project
 .settings
+
+# PSC files
+dropbox-psc.app
+user.json

--- a/src/main/java/ch/psc/domain/cipher/PlainTextCipher.java
+++ b/src/main/java/ch/psc/domain/cipher/PlainTextCipher.java
@@ -1,5 +1,8 @@
 package ch.psc.domain.cipher;
 
+import java.util.HashMap;
+import java.util.Map;
+import javax.crypto.Cipher;
 import javax.crypto.NullCipher;
 import ch.psc.exceptions.FatalImplementationException;
 
@@ -32,14 +35,19 @@ public class PlainTextCipher extends PscCipher {
   }
 
   @Override
-  protected javax.crypto.Cipher getCipher() throws FatalImplementationException {
+  protected Cipher getCipher() throws FatalImplementationException {
     javax.crypto.Cipher cipher = new NullCipher();
     return cipher;
   }
-
+  
   @Override
   public int getKeyBits() {
     return 16;
+  }
+
+  @Override
+  public Map<String, Key> generateKey() throws ch.psc.domain.error.FatalImplementationException {
+    return new HashMap<>();
   }
 
 }

--- a/src/main/java/ch/psc/gui/SignUpController.java
+++ b/src/main/java/ch/psc/gui/SignUpController.java
@@ -81,7 +81,7 @@ public class SignUpController extends ControlledScreen {
         User user =
                 new User(
                         (String) data.get(0), (String) data.get(1), (String) data.get(2),
-                        (Map<StorageService, Map<String, String>>) data.get(3), null
+                        (Map<StorageService, Map<String, String>>) data.get(4), null
                         //TODO null must be changed to Map<String, Key> later
                 );
         user.save();


### PR DESCRIPTION
Fixes #49 
Since the Cipher selection is before the Storage selection, we messed up the indexes in ```flowControl.getData()```